### PR TITLE
Correct Perp Volumes (retrieves from SquidRouter)

### DIFF
--- a/config/synthetics.ts
+++ b/config/synthetics.ts
@@ -19,6 +19,15 @@ export const SYNTHETICS_SUBGRAPHS: { [key: number]: string } = {
     'https://subgraph.satsuma-prod.com/3b2ced13c8d9/gmx/synthetics-botanix-stats/api',
 }
 
+export const SQUID_SYNTHETICS_SUBGRAPHS: { [key: number]: string } = {
+  [ARBITRUM]:
+    'https://gmx.squids.live/gmx-synthetics-arbitrum:prod/api/graphql',
+  [AVALANCHE]:
+    'https://gmx.squids.live/gmx-synthetics-avalanche:prod/api/graphql',
+  [BOTANIX]:
+    'https://gmx.squids.live/gmx-synthetics-botanix:prod/api/graphql',
+}
+
 export type Token = {
   name: string
   symbol: string

--- a/utils/synthetics/getPerpetualPairsInfo.ts
+++ b/utils/synthetics/getPerpetualPairsInfo.ts
@@ -40,7 +40,7 @@ export async function getPerpetualPairsInfo(
       const priceInfo = prices.find((price) =>
         isSameStr(price.tokenSymbol, tokenSymbol)
       )
-      const volumeUsd = volumeInfo[indexToken]
+      const volumeUsd = volumeInfo[marketToken] === undefined ? 0 :volumeInfo[marketToken];
       const gmLiquidityInfo = liquidityInfo[marketToken]
       const longTokenSymbol = market.longTokenInfo.symbol;
       const shortTokenSymbol = market.shortTokenInfo.symbol;


### PR DESCRIPTION
Previously it was pulling from the satsuma subgraph for the perps volume, but this was only based on the index, now with the SquidRouter subgraph you can pull it based on `marketAddress`.